### PR TITLE
Upgrade rake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 /.bundle/
 /.yardoc
-/Gemfile.lock
 /_yardoc/
 /coverage/
 /doc/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,51 @@
+PATH
+  remote: .
+  specs:
+    mathtype (0.1.0)
+      bindata (~> 2.1)
+      nokogiri (~> 1.6)
+      ruby-ole (~> 1.2)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    bindata (2.4.8)
+    coderay (1.1.1)
+    diff-lcs (1.3)
+    method_source (0.8.2)
+    mini_portile2 (2.4.0)
+    nokogiri (1.10.10)
+      mini_portile2 (~> 2.4.0)
+    pry (0.10.4)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    rake (13.0.1)
+    rspec (3.6.0)
+      rspec-core (~> 3.6.0)
+      rspec-expectations (~> 3.6.0)
+      rspec-mocks (~> 3.6.0)
+    rspec-core (3.6.0)
+      rspec-support (~> 3.6.0)
+    rspec-expectations (3.6.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.6.0)
+    rspec-mocks (3.6.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.6.0)
+    rspec-support (3.6.0)
+    ruby-ole (1.2.12.2)
+    slop (3.6.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bundler (> 1.7)
+  mathtype!
+  pry (~> 0.10)
+  rake (>= 12.3.3)
+  rspec (~> 3.3)
+
+BUNDLED WITH
+   1.15.4

--- a/mathtype.gemspec
+++ b/mathtype.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "> 1.7"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency "rspec", "~> 3.3"
   spec.add_development_dependency "pry", "~> 0.10"
   spec.add_dependency "bindata", "~> 2.1"


### PR DESCRIPTION
Seems like rake had a security vulnerability prior to 12.3.3, so I've updated that. I don't think you can exploit it through this gem, but upgrades usually don't hurt :)

I've also committed the Gemfile.lock, as I'm quite used to it being in version control in JS projects, and there seems to be agreement in the Ruby community now too: https://johnmaddux.com/2019/08/14/should-you-add-gemfile-lock-to-git/